### PR TITLE
Add tags, client-side filtering, TOC, reading progress, and related-posts to blog

### DIFF
--- a/src/collections/blog.ts
+++ b/src/collections/blog.ts
@@ -10,6 +10,7 @@ export const blogCollection = defineCollection({
       description: z.string(),
       publishedAt: z.coerce.date(),
       featuredImage: z.optional(image()),
+      tags: z.array(z.string()).default([]),
     }),
 })
 

--- a/src/components/blog/PostCard.astro
+++ b/src/components/blog/PostCard.astro
@@ -11,11 +11,11 @@ interface Props {
 }
 
 const { post } = Astro.props
-const { date, formattedDate, readingTime } = getPostMetadata(post)
+const { date, formattedDate, readingTime, readingMinutes, tags } = getPostMetadata(post)
 const postPath = getBlogPostPath(post)
 ---
 
-<div class="flex flex-col gap-y-4 border-t py-6 first:border-t-0 first:pt-0 last:pb-0">
+<div data-post-card data-title={post.data.title} data-description={post.data.description} data-tags={tags.join(",")} data-published={post.data.publishedAt.getTime()} data-reading={readingMinutes} class="group flex flex-col gap-y-4 border-t py-6 first:border-t-0 first:pt-0 last:pb-0 transition-all duration-200">
   {
     post.data.featuredImage && (
       <a href={postPath}>
@@ -23,7 +23,7 @@ const postPath = getBlogPostPath(post)
           widths={[448]}
           loading="lazy"
           src={post.data.featuredImage}
-          class="max-w-md rounded-lg object-cover"
+          class="max-w-md rounded-lg object-cover transition-transform duration-200 group-hover:scale-[1.015]"
           alt={`Featured image for ${post.data.title}`}
           transition:name={`post-${post.id}-featured-image`}
         />
@@ -34,7 +34,7 @@ const postPath = getBlogPostPath(post)
   <article class="flex flex-col gap-2">
     <span
       transition:name={`post-${post.id}-meta`}
-      class="flex items-center gap-x-1 font-mono text-xs tracking-wide uppercase"
+      class="flex items-center gap-x-1 font-mono text-xs tracking-wide uppercase text-muted transition-colors group-hover:text-foreground"
     >
       <time datetime={date}>{formattedDate}</time>
       <DotIcon size="14" class="shrink-0" />
@@ -46,5 +46,8 @@ const postPath = getBlogPostPath(post)
     <p transition:name={`post-${post.id}-description`} class="max-w-prose leading-relaxed text-pretty">
       {post.data.description}
     </p>
+    <div class="flex flex-wrap gap-2 pt-1">
+      {tags.map((tag) => <a href={`/blog/tag/${tag.toLowerCase().replaceAll(" ", "-")}`} class="rounded-full border px-2 py-0.5 text-xs no-underline">{tag}</a>)}
+    </div>
   </article>
 </div>

--- a/src/content/blog/my-first-post/index.mdx
+++ b/src/content/blog/my-first-post/index.mdx
@@ -3,6 +3,10 @@ title: Hello, world!
 description: The first post of many to come. A quick intro to the new website, and why I rebuilt it from scratch.
 publishedAt: 2026-05-01
 featuredImage: ./featured-image.png
+tags:
+  - Astro
+  - Web Performance
+  - Personal Website
 ---
 
 import { Image } from "astro:assets"

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -6,71 +6,81 @@ import { render } from "astro:content"
 import { type BlogPost, getBlogPosts } from "@/collections/blog"
 import { getBlogPostSchema } from "@/data/site"
 import MainLayout from "@/layouts/MainLayout.astro"
-import { getPostMetadata } from "@/utils/post"
-import { getBlogPostSlug } from "@/utils/url"
+import { getPostMetadata, getRelatedPosts } from "@/utils/post"
+import { getBlogPostSlug, getBlogPostPath } from "@/utils/url"
 
-interface Props {
-  post: BlogPost
-}
+interface Props { post: BlogPost }
 
 export async function getStaticPaths() {
   const posts = await getBlogPosts()
-
-  return posts.map((post) => ({
-    params: { slug: getBlogPostSlug(post) },
-    props: { post },
-  }))
+  return posts.map((post) => ({ params: { slug: getBlogPostSlug(post) }, props: { post } }))
 }
 
 const { post } = Astro.props
 const { Content } = await render(post)
 const blogPostSchema = getBlogPostSchema(post)
-const { date, formattedDate, readingTime } = getPostMetadata(post)
+const { date, formattedDate, readingTime, tags } = getPostMetadata(post)
+const relatedPosts = getRelatedPosts(post, await getBlogPosts())
 ---
 
 <MainLayout title={`${post.data.title} · amruth pillai`} description={post.data.description}>
   <script is:inline type="application/ld+json" set:html={JSON.stringify(blogPostSchema)} />
+  <div id="reading-progress" class="fixed top-0 left-0 z-50 h-0.5 w-0 bg-foreground"></div>
 
   <article class="my-18 space-y-8 sm:my-30 sm:space-y-12">
     <header class="flex flex-col gap-y-4">
-      {
-        post.data.featuredImage && (
-          <Image
-            widths={[768]}
-            loading="lazy"
-            src={post.data.featuredImage}
-            class="mb-2 rounded-md object-cover"
-            alt={`Featured image for ${post.data.title}`}
-            transition:name={`post-${post.id}-featured-image`}
-          />
-        )
-      }
-
-      <p
-        transition:name={`post-${post.id}-meta`}
-        class="flex items-center gap-x-1 font-mono text-xs tracking-wide uppercase"
-      >
-        <time datetime={date}>{formattedDate}</time>
-        <DotIcon size="14" class="shrink-0" />
-        <span>{readingTime}</span>
+      {post.data.featuredImage && <Image widths={[768]} loading="lazy" src={post.data.featuredImage} class="mb-2 rounded-md object-cover" alt={`Featured image for ${post.data.title}`} transition:name={`post-${post.id}-featured-image`} />}
+      <p transition:name={`post-${post.id}-meta`} class="flex items-center gap-x-1 font-mono text-xs tracking-wide uppercase">
+        <time datetime={date}>{formattedDate}</time><DotIcon size="14" class="shrink-0" /><span>{readingTime}</span>
       </p>
-      <h1 transition:name={`post-${post.id}-title`} class="text-3xl font-semibold tracking-tight sm:text-5xl">
-        {post.data.title}
-      </h1>
-      <p
-        transition:name={`post-${post.id}-description`}
-        class="max-w-prose text-base/relaxed text-pretty text-muted sm:text-lg/relaxed"
-      >
-        {post.data.description}
-      </p>
+      <h1 transition:name={`post-${post.id}-title`} class="text-3xl font-semibold tracking-tight sm:text-5xl">{post.data.title}</h1>
+      <p transition:name={`post-${post.id}-description`} class="max-w-prose text-base/relaxed text-pretty text-muted sm:text-lg/relaxed">{post.data.description}</p>
+      <div class="flex flex-wrap gap-2">{tags.map((tag) => <a href={`/blog/tag/${tag.toLowerCase().replaceAll(" ", "-")}`} class="rounded-full border px-2 py-0.5 text-xs no-underline">{tag}</a>)}</div>
     </header>
 
+    <aside id="toc" class="hidden rounded-md border p-4 text-sm"></aside>
     <hr />
-
-    <div
-      class="prose max-w-none prose-stone dark:prose-invert prose-headings:font-heading prose-headings:tracking-tight prose-a:decoration-1 prose-a:underline-offset-4"
-    >
+    <div id="post-content" class="prose max-w-none prose-stone dark:prose-invert prose-headings:font-heading prose-headings:tracking-tight prose-a:decoration-1 prose-a:underline-offset-4">
       <Content />
     </div>
+
+    {relatedPosts.length > 0 && (
+      <section class="space-y-3 border-t pt-6">
+        <h2 class="text-xl font-semibold">Related posts</h2>
+        <ul class="space-y-2">
+          {relatedPosts.map((candidate) => <li><a href={getBlogPostPath(candidate)}>{candidate.data.title}</a></li>)}
+        </ul>
+      </section>
+    )}
   </article>
+
+  <button id="back-to-top" class="fixed right-5 bottom-5 hidden rounded-full border bg-background px-3 py-2 text-xs no-underline">top ↑</button>
+  <script is:inline>
+    const progress = document.querySelector('#reading-progress')
+    const article = document.querySelector('article')
+    const toc = document.querySelector('#toc')
+    const topBtn = document.querySelector('#back-to-top')
+    const headings = [...document.querySelectorAll('#post-content h2, #post-content h3')]
+
+    if (headings.length > 2) {
+      toc.classList.remove('hidden')
+      toc.innerHTML = `<p class="mb-2 font-medium">On this page</p>${headings.map((h) => {
+        if (!h.id) h.id = h.textContent.toLowerCase().replace(/[^a-z0-9]+/g, '-')
+        return `<a class="block no-underline ${h.tagName === 'H3' ? 'ml-4' : ''}" href="#${h.id}">${h.textContent}</a>`
+      }).join('')}`
+    }
+
+    const onScroll = () => {
+      const rect = article.getBoundingClientRect()
+      const total = rect.height - window.innerHeight
+      const read = Math.min(Math.max(-rect.top, 0), total)
+      const pct = total > 0 ? (read / total) * 100 : 0
+      if (progress) progress.style.width = `${pct}%`
+      topBtn?.classList.toggle('hidden', window.scrollY < 500)
+    }
+
+    window.addEventListener('scroll', onScroll, { passive: true })
+    onScroll()
+    topBtn?.addEventListener('click', () => window.scrollTo({ top: 0, behavior: 'smooth' }))
+  </script>
 </MainLayout>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -2,15 +2,17 @@
 import { getBlogPosts } from "@/collections/blog"
 import PostCard from "@/components/blog/PostCard.astro"
 import MainLayout from "@/layouts/MainLayout.astro"
+import { getAllTags } from "@/utils/post"
 
 const posts = await getBlogPosts()
+const tags = getAllTags(posts)
 ---
 
 <MainLayout
   title="blog · amruth pillai"
   description="my rambling thoughts on design, development, and building on the web."
 >
-  <section class="my-18 space-y-18 sm:my-30 sm:space-y-30">
+  <section class="my-18 space-y-10 sm:my-30 sm:space-y-12">
     <header class="space-y-3">
       <h1 class="text-5xl leading-none font-semibold tracking-tight">blog</h1>
       <p class="max-w-prose leading-relaxed text-pretty text-muted">
@@ -18,8 +20,64 @@ const posts = await getBlogPosts()
       </p>
     </header>
 
-    <div>
+    <div class="space-y-4">
+      <input id="blog-search" type="search" placeholder="search posts..." class="w-full rounded-md border bg-transparent px-3 py-2" />
+      <div class="flex flex-wrap gap-2">
+        <button data-tag="all" class="tag-filter active rounded-full border px-3 py-1 text-xs no-underline">all</button>
+        {tags.map((tag) => <button data-tag={tag} class="tag-filter rounded-full border px-3 py-1 text-xs no-underline">{tag}</button>)}
+      </div>
+      <select id="blog-sort" class="rounded-md border bg-transparent px-3 py-2">
+        <option value="newest">newest</option>
+        <option value="oldest">oldest</option>
+        <option value="reading">reading time</option>
+      </select>
+    </div>
+
+    <div id="blog-list">
       {posts.map((post) => <PostCard post={post} />)}
     </div>
+    <p id="blog-empty" class="hidden text-muted">No posts match your filters.</p>
   </section>
+
+  <script is:inline>
+    const cards = [...document.querySelectorAll('[data-post-card]')]
+    const search = document.querySelector('#blog-search')
+    const sort = document.querySelector('#blog-sort')
+    const tagButtons = [...document.querySelectorAll('.tag-filter')]
+    const empty = document.querySelector('#blog-empty')
+    let activeTag = 'all'
+
+    const getValue = (node, key) => node.dataset[key] || ''
+
+    const render = () => {
+      const term = (search?.value || '').toLowerCase().trim()
+      const sortValue = sort?.value || 'newest'
+
+      const visible = cards.filter((card) => {
+        const haystack = `${getValue(card, 'title')} ${getValue(card, 'description')} ${getValue(card, 'tags')}`.toLowerCase()
+        const hasTerm = !term || haystack.includes(term)
+        const hasTag = activeTag === 'all' || getValue(card, 'tags').split(',').includes(activeTag)
+        return hasTerm && hasTag
+      })
+
+      cards.sort((a, b) => {
+        if (sortValue === 'oldest') return Number(getValue(a, 'published')) - Number(getValue(b, 'published'))
+        if (sortValue === 'reading') return Number(getValue(a, 'reading')) - Number(getValue(b, 'reading'))
+        return Number(getValue(b, 'published')) - Number(getValue(a, 'published'))
+      }).forEach((card) => card.parentElement.appendChild(card))
+
+      cards.forEach((card) => card.classList.toggle('hidden', !visible.includes(card)))
+      empty?.classList.toggle('hidden', visible.length > 0)
+    }
+
+    search?.addEventListener('input', render)
+    sort?.addEventListener('change', render)
+    tagButtons.forEach((button) => {
+      button.addEventListener('click', () => {
+        activeTag = button.dataset.tag || 'all'
+        tagButtons.forEach((btn) => btn.classList.toggle('active', btn === button))
+        render()
+      })
+    })
+  </script>
 </MainLayout>

--- a/src/pages/blog/tag/[tag].astro
+++ b/src/pages/blog/tag/[tag].astro
@@ -1,0 +1,26 @@
+---
+import { getBlogPosts } from "@/collections/blog"
+import PostCard from "@/components/blog/PostCard.astro"
+import MainLayout from "@/layouts/MainLayout.astro"
+
+export async function getStaticPaths() {
+  const posts = await getBlogPosts()
+  const tags = [...new Set(posts.flatMap((post) => post.data.tags ?? []))]
+  return tags.map((tag) => ({ params: { tag: tag.toLowerCase().replaceAll(" ", "-") }, props: { tag } }))
+}
+
+const { tag } = Astro.props
+const posts = (await getBlogPosts()).filter((post) => (post.data.tags ?? []).includes(tag))
+---
+
+<MainLayout title={`${tag} · blog · amruth pillai`} description={`Posts tagged ${tag}`}>
+  <section class="my-18 space-y-10 sm:my-30 sm:space-y-12">
+    <header class="space-y-3">
+      <h1 class="text-4xl font-semibold tracking-tight">tag: {tag}</h1>
+      <p class="text-muted">{posts.length} post(s)</p>
+    </header>
+    <div>
+      {posts.map((post) => <PostCard post={post} />)}
+    </div>
+  </section>
+</MainLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -73,3 +73,18 @@
     font-weight: 600;
   }
 }
+
+@layer components {
+  .tag-filter.active {
+    @apply bg-foreground text-background;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/src/utils/post.ts
+++ b/src/utils/post.ts
@@ -6,11 +6,32 @@ import { formatDate } from "./date"
 
 export function getPostMetadata(post: BlogPost) {
   const body = post.body?.toString() ?? ""
-  const { text: readingTime } = getReadingTime(body)
+  const { text: readingTime, minutes } = getReadingTime(body)
 
   return {
     date: post.data.publishedAt.toISOString(),
     formattedDate: formatDate(post.data.publishedAt),
     readingTime,
+    readingMinutes: Math.ceil(minutes),
+    tags: post.data.tags ?? [],
   }
+}
+
+export function getAllTags(posts: BlogPost[]) {
+  return [...new Set(posts.flatMap((post) => post.data.tags ?? []))].sort((a, b) => a.localeCompare(b))
+}
+
+export function getRelatedPosts(post: BlogPost, posts: BlogPost[], limit = 3) {
+  const tags = new Set(post.data.tags ?? [])
+
+  return posts
+    .filter((candidate) => candidate.id !== post.id)
+    .map((candidate) => {
+      const overlap = (candidate.data.tags ?? []).filter((tag) => tags.has(tag)).length
+      return { candidate, overlap }
+    })
+    .filter(({ overlap }) => overlap > 0)
+    .sort((a, b) => b.overlap - a.overlap || b.candidate.data.publishedAt.getTime() - a.candidate.data.publishedAt.getTime())
+    .slice(0, limit)
+    .map(({ candidate }) => candidate)
 }


### PR DESCRIPTION
### Motivation
- Improve blog discoverability and UX by adding tags, client-side search/sort/filter controls, and tag listing pages. 
- Enhance individual post experience with reading progress, a generated table-of-contents, related-post suggestions, and small visual/interaction polish. 

### Description
- Add `tags` to the blog collection schema with a default of `[]` and update example post frontmatter to include tags. 
- Extend `getPostMetadata` to return `readingMinutes` and `tags`, and add `getAllTags` and `getRelatedPosts` helpers in `src/utils/post.ts`. 
- Update `PostCard` to include data attributes for client-side filtering, display tag chips, and add hover/transition styles; update global CSS with `.tag-filter.active` and reduced-motion rules. 
- Implement client-side blog list UI in `src/pages/blog/index.astro` (search, sort, tag filters), add a tag route at `src/pages/blog/tag/[tag].astro`, and enhance post pages in `src/pages/blog/[...slug].astro` with tags, a reading progress bar, generated TOC, related posts, back-to-top button, and associated inline scripts. 

### Testing
- Ran a full site build with `npm run build`, which completed successfully. 
- Ran type checking with `npm run typecheck` (or `tsc --noEmit`), which reported no type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3b9c589288325aaea0aae4ebc1063)